### PR TITLE
Call only close-session rpc in close method

### DIFF
--- a/lib/netconf.js
+++ b/lib/netconf.js
@@ -185,11 +185,11 @@ class Client extends EventEmitter {
     }
 
     /**
-     * Closes the SSH connection to netconf, emits close event
+     * Closes the SSH connection to netconf
      * @function close
      * @param  {Function} callback Callback function fired after netconf session ends
      */
-    close(callback){
+    close(callback) {
         const self = this;
 
         // send close-session request to netconf
@@ -197,14 +197,11 @@ class Client extends EventEmitter {
             // close out SSH tunnel
             self.sshConn.end();
             self.connected = false;
-            self.netconf = void 0;
 
-            // if callback funciton passed, continue with callback
+            // if callback function is passed, continue with callback
             if(typeof callback === 'function'){
-                callback();
+                callback(err, reply);
             }
-
-            self.emit('close');
         });
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-netconf",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Pure JavaScript NETCONF library.",
   "main": "lib/netconf.js",
   "directories": {


### PR DESCRIPTION
a. Call rpc close-session in close netconf session method
b. Do not emit on close event, instead call the callback function
that is supplied as input argument